### PR TITLE
js-custom-operators 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# js-custom-operators [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/js-custom-operators.svg)](https://www.npmjs.com/package/js-custom-operators) [![Downloads](https://img.shields.io/npm/dt/js-custom-operators.svg)](https://www.npmjs.com/package/js-custom-operators) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# js-custom-operators
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/js-custom-operators.svg)](https://www.npmjs.com/package/js-custom-operators) [![Downloads](https://img.shields.io/npm/dt/js-custom-operators.svg)](https://www.npmjs.com/package/js-custom-operators) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Create your own operators in JavaScript
 
@@ -33,7 +35,7 @@ Then `x ⋂ y` will return the same thing. :-)
 
 ## Live demo
 
-You can try this application online [clicking here](http://ionicabizau.github.io/js-custom-operators/).
+You can try this application online [clicking here](http://ionicabizau.github.io/JavaScript-custom-operators/).
 
 
 [![js-custom-operators](http://i.imgur.com/15IaZnT.png)](#)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-custom-operators",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Create your own operators in JavaScript",
   "main": "lib/index.js",
   "scripts": {
@@ -88,6 +88,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
